### PR TITLE
Clone target to support more cases

### DIFF
--- a/__tests__/__snapshots__/integration-test.js.snap
+++ b/__tests__/__snapshots__/integration-test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`click on a detached image doesn’t add classes 1`] = `
+<body>
+  <img
+    class=""
+  />
+</body>
+`;
+
+exports[`click on an image renders correctly 1`] = `
+<body>
+  <img
+    class="medium-zoom-image"
+    style="visibility: hidden;"
+  />
+  <div
+    class="medium-zoom-overlay"
+    style="background-color: rgb(255, 255, 255);"
+  />
+  <img
+    class="medium-zoom-image medium-zoom-image--open"
+    style="position: absolute; top: 0px; left: 0px; width: 0px;"
+  />
+</body>
+`;

--- a/__tests__/__snapshots__/medium-zoom-test.js.snap
+++ b/__tests__/__snapshots__/medium-zoom-test.js.snap
@@ -22,11 +22,16 @@ exports[`hide renders correctly 1`] = `
 exports[`show renders correctly 1`] = `
 <body>
   <img
-    class="medium-zoom-image medium-zoom-image--open"
+    class="medium-zoom-image"
+    style="visibility: hidden;"
   />
   <div
     class="medium-zoom-overlay"
     style="background-color: rgb(255, 255, 255);"
+  />
+  <img
+    class="medium-zoom-image medium-zoom-image--open"
+    style="position: absolute; top: 0px; left: 0px; width: 0px;"
   />
 </body>
 `;
@@ -34,23 +39,16 @@ exports[`show renders correctly 1`] = `
 exports[`show renders correctly with options overlay background 1`] = `
 <body>
   <img
-    class="medium-zoom-image medium-zoom-image--open"
+    class="medium-zoom-image"
+    style="visibility: hidden;"
   />
   <div
     class="medium-zoom-overlay"
     style="background-color: rgb(186, 218, 85);"
   />
-</body>
-`;
-
-exports[`update with background updates the background option, returns all options and renders correctly 1`] = `
-<body>
   <img
     class="medium-zoom-image medium-zoom-image--open"
-  />
-  <div
-    class="medium-zoom-overlay"
-    style="background-color: rgb(0, 0, 0);"
+    style="position: absolute; top: 0px; left: 0px; width: 0px;"
   />
 </body>
 `;

--- a/__tests__/integration-test.js
+++ b/__tests__/integration-test.js
@@ -3,25 +3,27 @@ const mediumZoom = require('../src/medium-zoom')
 
 global.requestAnimationFrame = cb => setTimeout(cb, 0)
 
+const root = document.body
+
+beforeEach(() => {
+  while (root.firstChild) {
+    root.removeChild(root.firstChild)
+  }
+})
+
 describe('click', () => {
-  const root = document.body
-
-  beforeEach(() => {
-    while (root.firstChild) {
-      root.removeChild(root.firstChild)
-    }
-  })
-
-  test('on an image adds classes', () => {
+  test('on an image renders correctly', () => {
     const image = document.createElement('img')
     root.appendChild(image)
 
     mediumZoom('img')
 
     image.click()
-    const classNames = [...image.classList]
 
-    expect(classNames).toEqual(['medium-zoom-image', 'medium-zoom-image--open'])
+    expect(image.className).toBe('medium-zoom-image')
+    expect(document.querySelector('.medium-zoom-image--open')).toBeTruthy()
+    expect(document.querySelector('.medium-zoom-overlay')).toBeTruthy()
+    expect(root).toMatchSnapshot()
   })
 
   test('on a detached image doesn’t add classes', () => {
@@ -34,5 +36,6 @@ describe('click', () => {
     image.click()
 
     expect(image.classList).toHaveLength(0)
+    expect(root).toMatchSnapshot()
   })
 })

--- a/__tests__/medium-zoom-test.js
+++ b/__tests__/medium-zoom-test.js
@@ -226,7 +226,7 @@ describe('update', () => {
 
     expect(options).toEqual(expected)
     expect(zoom.options).toEqual(expected)
-    expect(root).toMatchSnapshot()
+    expect(document.querySelector('.medium-zoom-overlay').style.backgroundColor).toBe('rgb(0, 0, 0)')
   })
 
   test('with scroll offset updates the scroll offset option and returns all options', () => {
@@ -285,9 +285,10 @@ describe('show', () => {
 
     const zoom = mediumZoom('img')
     zoom.show()
-    const classNames = [...image.classList]
 
-    expect(classNames).toEqual(['medium-zoom-image', 'medium-zoom-image--open'])
+    expect(image.className).toBe('medium-zoom-image')
+    expect(document.querySelector('.medium-zoom-image--open')).toBeTruthy()
+    expect(document.querySelector('.medium-zoom-overlay')).toBeTruthy()
     expect(root).toMatchSnapshot()
   })
 

--- a/examples/javascript/demo.js
+++ b/examples/javascript/demo.js
@@ -8,9 +8,7 @@
 
   // Add a zoom to be detached
   var zoomToDetach = mediumZoom('#zoom-detach')
-  setTimeout(function () {
-    zoomToDetach.detach()
-  }, 5000)
+  zoomToDetach.addEventListeners('hidden', zoomToDetach.detach)
 
   // Add zooms to a container
   var containerZoom = [

--- a/examples/javascript/development/index.html
+++ b/examples/javascript/development/index.html
@@ -160,9 +160,9 @@
         <img
           id="zoom-detach"
           src="../images/image-7.jpg"
-          alt="Zoom detached after 5 seconds"
+          alt="Zoom detached after being zoomed once"
         >
-        <figcaption>Zoom detached after 5 seconds</figcaption>
+        <figcaption>Zoom detached after being zoomed once</figcaption>
       </figure>
 
       <h2>Journal</h2>

--- a/examples/javascript/preview/index.html
+++ b/examples/javascript/preview/index.html
@@ -26,6 +26,34 @@
     </header>
 
     <article class="container">
+
+      <h2>Images in `overflow: hidden` containers</h2>
+
+      <div class="layout">
+        <div class="content">
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1502508512528-19b6a9fa4e95?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1920&fit=max&s=3b05e061cf6220cd16eeed6adf3be515" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1502772066658-3006ff41449b?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1920&fit=max&s=6fa8ec1e3b33dc527d677aa37e14661a" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1488217820102-3ef7cfe8bb4e?dpr=1&auto=compress,format&fit=crop&w=1920&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1495548774443-1f50ef99b0d2?dpr=1&auto=compress,format&fit=crop&w=1268&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1481671703460-040cb8a2d909?dpr=1&auto=compress,format&fit=crop&w=668&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1496806195556-91bdded94209?dpr=1&auto=compress,format&fit=crop&w=1350&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+        </div>
+      </div>
+
+      <h2>Usual demo</h2>
+
       <figure>
         <img
           id="zoom-default"
@@ -198,6 +226,8 @@
 
     <script>
       console.info('You\'re in preview environment 🖥')
+
+      mediumZoom('.container-overflow')
     </script>
     <script src="medium-zoom.min.js"></script>
     <script src="../demo.js"></script>

--- a/examples/javascript/preview/index.html
+++ b/examples/javascript/preview/index.html
@@ -224,12 +224,12 @@
       <p><a href="#">Back to top</a></p>
     </footer>
 
+    <script src="medium-zoom.min.js"></script>
     <script>
       console.info('You\'re in preview environment 🖥')
 
       mediumZoom('.container-overflow')
     </script>
-    <script src="medium-zoom.min.js"></script>
     <script src="../demo.js"></script>
   </body>
 </html>

--- a/examples/javascript/preview/index.html
+++ b/examples/javascript/preview/index.html
@@ -27,33 +27,6 @@
 
     <article class="container">
 
-      <h2>Images in `overflow: hidden` containers</h2>
-
-      <div class="layout">
-        <div class="content">
-          <div class="card">
-            <img class="container-overflow" src="https://images.unsplash.com/photo-1502508512528-19b6a9fa4e95?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1920&fit=max&s=3b05e061cf6220cd16eeed6adf3be515" alt="">
-          </div>
-          <div class="card">
-            <img class="container-overflow" src="https://images.unsplash.com/photo-1502772066658-3006ff41449b?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1920&fit=max&s=6fa8ec1e3b33dc527d677aa37e14661a" alt="">
-          </div>
-          <div class="card">
-            <img class="container-overflow" src="https://images.unsplash.com/photo-1488217820102-3ef7cfe8bb4e?dpr=1&auto=compress,format&fit=crop&w=1920&h=&q=80&cs=tinysrgb&crop=" alt="">
-          </div>
-          <div class="card">
-            <img class="container-overflow" src="https://images.unsplash.com/photo-1495548774443-1f50ef99b0d2?dpr=1&auto=compress,format&fit=crop&w=1268&h=&q=80&cs=tinysrgb&crop=" alt="">
-          </div>
-          <div class="card">
-            <img class="container-overflow" src="https://images.unsplash.com/photo-1481671703460-040cb8a2d909?dpr=1&auto=compress,format&fit=crop&w=668&h=&q=80&cs=tinysrgb&crop=" alt="">
-          </div>
-          <div class="card">
-            <img class="container-overflow" src="https://images.unsplash.com/photo-1496806195556-91bdded94209?dpr=1&auto=compress,format&fit=crop&w=1350&h=&q=80&cs=tinysrgb&crop=" alt="">
-          </div>
-        </div>
-      </div>
-
-      <h2>Usual demo</h2>
-
       <figure>
         <img
           id="zoom-default"
@@ -188,10 +161,35 @@
         <img
           id="zoom-detach"
           src="../images/image-7.jpg"
-          alt="Zoom detached after 5 seconds"
+          alt="Zoom detached after being zoomed once"
         >
-        <figcaption>Zoom detached after 5 seconds</figcaption>
+        <figcaption>Zoom detached after being zoomed once</figcaption>
       </figure>
+
+      <h2>Images in `overflow: hidden` containers</h2>
+
+      <div class="layout">
+        <div class="content">
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1502508512528-19b6a9fa4e95?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1920&fit=max&s=3b05e061cf6220cd16eeed6adf3be515" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1502772066658-3006ff41449b?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1920&fit=max&s=6fa8ec1e3b33dc527d677aa37e14661a" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1488217820102-3ef7cfe8bb4e?dpr=1&auto=compress,format&fit=crop&w=1920&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1495548774443-1f50ef99b0d2?dpr=1&auto=compress,format&fit=crop&w=1268&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1481671703460-040cb8a2d909?dpr=1&auto=compress,format&fit=crop&w=668&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+          <div class="card">
+            <img class="container-overflow" src="https://images.unsplash.com/photo-1496806195556-91bdded94209?dpr=1&auto=compress,format&fit=crop&w=1350&h=&q=80&cs=tinysrgb&crop=" alt="">
+          </div>
+        </div>
+      </div>
 
       <h2>Journal</h2>
 

--- a/examples/javascript/style.css
+++ b/examples/javascript/style.css
@@ -216,3 +216,21 @@ pre {
     margin-left: -92px;
   }
 }
+
+.card {
+  vertical-align: middle;
+  display: inline-block;
+  box-sizing: border-box;
+  max-width: 350px;
+  width: 30%;
+  margin: 16px 4px;
+  background: #fff;
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .24);
+}
+
+.card img {
+  width: 100%;
+  display: block;
+}

--- a/src/medium-zoom.css
+++ b/src/medium-zoom.css
@@ -18,7 +18,7 @@
 .medium-zoom-image {
   cursor: pointer;
   cursor: zoom-in;
-  transition: all 300ms;
+  transition: transform 300ms;
 }
 
 .medium-zoom-image--open {

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -77,8 +77,7 @@ const mediumZoom = (selector, {
   const zoom = () => {
     if (!target.template) return
 
-    const event = new Event('show')
-    target.template.dispatchEvent(event)
+    target.template.dispatchEvent(new Event('show'))
 
     scrollTop = document.documentElement.scrollTop || document.body.scrollTop
     isAnimating = true
@@ -100,12 +99,11 @@ const mediumZoom = (selector, {
     animateTarget()
   }
 
-  const zoomOut = () => {
-    setTimeout(() => {
-      if (!target.template) return
+  const zoomOut = (timeout = 0) => {
+    const doZoomOut = () => {
+      if (isAnimating || !target.template) return
 
-      const event = new Event('hide')
-      target.template.dispatchEvent(event)
+      target.template.dispatchEvent(new Event('hide'))
 
       isAnimating = true
       document.body.classList.remove('medium-zoom--open')
@@ -113,7 +111,9 @@ const mediumZoom = (selector, {
 
       target.zoomed.removeEventListener('click', zoomOut)
       target.zoomed.addEventListener('transitionend', onZoomOutEnd)
-    }, 150)
+    }
+
+    (timeout > 0) ? setTimeout(doZoomOut, timeout) : doZoomOut()
   }
 
   const triggerZoom = event => {
@@ -126,9 +126,8 @@ const mediumZoom = (selector, {
   }
 
   const update = (newOptions = {}) => {
-    if (newOptions.background) {
-      overlay.style.backgroundColor = newOptions.background
-    }
+    newOptions.background &&
+      (overlay.style.backgroundColor = newOptions.background)
 
     return Object.assign(options, newOptions)
   }
@@ -151,9 +150,8 @@ const mediumZoom = (selector, {
 
       images.splice(0, images.length)
 
-      if (target.zoomed) {
+      target.zoomed &&
         target.zoomed.removeEventListener('transitionend', doDetach)
-      }
     }
 
     if (!target.zoomed) {
@@ -184,8 +182,7 @@ const mediumZoom = (selector, {
     isAnimating = false
     target.zoomed.removeEventListener('transitionend', onZoomEnd)
 
-    const event = new Event('shown')
-    target.template.dispatchEvent(event)
+    target.template.dispatchEvent(new Event('shown'))
   }
 
   const onZoomOutEnd = () => {
@@ -199,8 +196,7 @@ const mediumZoom = (selector, {
     isAnimating = false
     target.zoomed.removeEventListener('transitionend', onZoomOutEnd)
 
-    const event = new Event('hidden')
-    target.template.dispatchEvent(event)
+    target.template.dispatchEvent(new Event('hidden'))
 
     target.template = null
     target.zoomed = null
@@ -212,7 +208,7 @@ const mediumZoom = (selector, {
     const currentScroll = document.documentElement.scrollTop || document.body.scrollTop
 
     if (Math.abs(scrollTop - currentScroll) > options.scrollOffset) {
-      zoomOut()
+      zoomOut(150)
     }
   }
 

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -233,14 +233,11 @@ const mediumZoom = (selector, {
 
     const { naturalWidth = +Infinity, naturalHeight = +Infinity } = target.template
     const { top, left, width, height } = target.template.getBoundingClientRect()
-    const isCenterAligned = Math.abs((windowWidth / 2) - (left + (width / 2))) <= 10
 
     const scaleX = Math.min(naturalWidth, viewportWidth) / width
     const scaleY = Math.min(naturalHeight, viewportHeight) / height
     const scale = Math.min(scaleX, scaleY) || 1
-    const translateX = isCenterAligned
-      ? 0
-      : (-left + ((viewportWidth - width) / 2) + options.margin) / scale
+    const translateX = (-left + ((viewportWidth - width) / 2) + options.margin) / scale
     const translateY = (-top + ((viewportHeight - height) / 2) + options.margin) / scale
 
     target.zoomed.style.transform = `scale(${scale}) translate3d(${translateX}px, ${translateY}px, 0)`

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -161,7 +161,7 @@ const mediumZoom = (selector, {
       doDetach()
     } else {
       zoomOut()
-      target.zoomed.addEventListener('transitionend', doDetach)
+      target.zoomed.addEventListener('transitionend', requestAnimationFrame(doDetach))
     }
   }
 

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -65,10 +65,13 @@ const mediumZoom = (selector, {
   const cloneTarget = template => {
     const { top, left, width } = template.getBoundingClientRect()
     const clone = template.cloneNode()
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
+    const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0
+
     clone.removeAttribute('id')
     clone.style.position = 'absolute'
-    clone.style.top = `${top + window.scrollY}px`
-    clone.style.left = `${left + window.scrollX}px`
+    clone.style.top = `${top + scrollTop}px`
+    clone.style.left = `${left + scrollLeft}px`
     clone.style.width = `${width}px`
 
     return clone
@@ -79,7 +82,7 @@ const mediumZoom = (selector, {
 
     target.template.dispatchEvent(new Event('show'))
 
-    scrollTop = document.documentElement.scrollTop || document.body.scrollTop
+    scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
     isAnimating = true
     target.zoomed = cloneTarget(target.template)
 
@@ -205,7 +208,7 @@ const mediumZoom = (selector, {
   const onScroll = () => {
     if (isAnimating || !target.template) return
 
-    const currentScroll = document.documentElement.scrollTop || document.body.scrollTop
+    const currentScroll = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0
 
     if (Math.abs(scrollTop - currentScroll) > options.scrollOffset) {
       zoomOut(150)

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -109,7 +109,7 @@ const mediumZoom = (selector, {
 
       isAnimating = true
       document.body.classList.remove('medium-zoom--open')
-      target.zoomed.style.transform = 'none'
+      target.zoomed.style.transform = ''
 
       target.zoomed.removeEventListener('click', zoomOut)
       target.zoomed.addEventListener('transitionend', onZoomOutEnd)

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -152,6 +152,10 @@ const mediumZoom = (selector, {
       })
 
       images.splice(0, images.length)
+      overlay.removeEventListener('click', zoomOut)
+      document.removeEventListener('scroll', onScroll)
+      document.removeEventListener('keyup', onDismiss)
+      window.removeEventListener('resize', zoomOut)
 
       target.zoomed &&
         target.zoomed.removeEventListener('transitionend', doDetach)


### PR DESCRIPTION
**This is a brand new implementation of `medium-zoom` without any API changes.**

-----

This PR adds support for zooms in `overflow: hidden` containers (see #19, @antoinechalifour), but also for images having a `transform` property before being zoomed.

[Before](https://deploy-preview-20--medium-zoom.netlify.com/) → [After](https://deploy-preview-20--medium-zoom.netlify.com/preview/)

### Why

* Images in `overflow: hidden` containers stayed cropped when zoomed.
* Images lose their initial `transform` properties once zoomed.

### Solution

Clone the image and append it to the `body` so that it's not constraint to its parent or any of its previous properties. This clone needs to be at the exact same position as the original, without any `transform` property.

#### Steps

1. Clone the target
2. Position the clone with an `absolute` position
3. Add the clone to the DOM on `show` event
4. Hide the original target
5. Animate the clone
5. Animate the clone back to the original target position on `hide` event
6. Show the original image and remove the clone from the DOM

### Notes

#### Performance

I originally was concerned about performance, but we can still easily reach more than 60fps.

<img width="829" alt="mz-clone-perf" src="https://user-images.githubusercontent.com/6137112/30791510-eee32f70-a180-11e7-8efd-7ac96c6fb0df.png">

#### Animation

Since we duplicate the target image, it can trigger some fancy animations. It's something we need to be aware of.

![mz-oh-angle](https://user-images.githubusercontent.com/6137112/30791529-0a238dfc-a181-11e7-8874-e1507672be14.gif)

### Preview

[View preview](https://deploy-preview-20--medium-zoom.netlify.com/preview/)

-----

This PR will also make possible the implementation of #6 🎉 