### PR TITLE
Add support for custom containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 * 🖱 **Mouse, keyboard and gesture friendly** — *click anywhere, press a key or scroll away to dismiss the zoom*
 * 🎉 **Event handling** — *trigger events when the zoom enters a new state*
 * 🔧 **Customization** — *set your own margin, background and scroll offset*
+* 💎 **Custom renderer** — *extend the default look to match your UI*
 * 🔗 **Link support** — *open the link of the image in a new tab when a meta key is held (<kbd>⌘</kbd> or <kbd>Ctrl</kbd>)*
 * 🖼 **Image opener** — *when no link, open the image source in a new tab when a meta key is held (<kbd>⌘</kbd> or <kbd>Ctrl</kbd>)*
 
@@ -86,11 +87,12 @@ Import the script:
 <script src="node_modules/medium-zoom/dist/medium-zoom.min.js"></script>
 ```
 
-Or, using the module syntax:
+Or, using the module syntax or imports:
 
 ```js
 const mediumZoom = require('medium-zoom')
-// import mediumZoom from 'medium-zoom'
+// or
+import mediumZoom from 'medium-zoom'
 ```
 
 That's it! You don't need to import any CSS styles.
@@ -103,13 +105,13 @@ mediumZoom(<selector>, <options>)
 
 By default, the zoom is applied to all scaled images (with HTML or CSS properties). You can specify the zoomable images with a [CSS selector](http://www.w3schools.com/cssref/css_selectors.asp) and add [options](#options).
 
-Additionally, you can pass an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element), a [NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList), an [HTMLCollection](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection) or an array of images to the plugin.
+Additionally, you can pass an [HTML Element](https://developer.mozilla.org/en-US/docs/Web/API/Element), a [NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList), an [HTMLCollection](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection) or an array of images to the plugin.
 
 ```js
 // CSS selector
 mediumZoom('#cover')
 
-// Element
+// HTML Element
 mediumZoom(document.getElementById('cover'))
 
 // NodeList
@@ -135,18 +137,35 @@ Options can be passed via a JavaScript object through the `mediumZoom` call.
 
 | Properties   | Type    | Default  | Description                                                         |
 |--------------|---------|----------|---------------------------------------------------------------------|
-| margin       | integer | `0`      | Space outside the zoomed image                                      |
-| background   | string  | `"#fff"` | Color of the overlay                                                |
-| scrollOffset | integer | `48`     | Number of pixels to scroll to dismiss the zoom                      |
-| metaClick    | boolean | `true`   | Enables the action on meta click (opens the link / image source)    |
+| `margin`       | integer | `0`      | Space outside the zoomed image                                      |
+| `background`   | string  | `"#fff"` | Color of the overlay                                                |
+| `scrollOffset` | integer | `48`     | Number of pixels to scroll to dismiss the zoom                      |
+| `metaClick`    | boolean | `true`   | Enables the action on [meta click](https://en.wikipedia.org/wiki/Meta_key) (opens the link / image source)    |
+| `container`    | string \| Element | `undefined`   | [Template element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) to render the zoomed image in |
 
 ```js
 mediumZoom('[data-action="zoom"]', {
   margin: 24,
   background: '#000',
   scrollOffset: 0,
-  metaClick: false
+  metaClick: false,
+  container: '#zoom-container'
 })
+```
+
+#### Using a custom `container`
+
+You might want to render the zoom in your own container. You could reproduce zooms as seen on Facebook or Dropbox Paper. This is possible with the `container` option.
+
+1. Create a `template` element matching the `container` option value
+2. If you'd like your image to appear at a specific location in your template, specify the `data-zoom-container` attribute on the element
+
+```html
+<template id="zoom-container">
+  <header>My image zoom template</header>
+  <div data-zoom-container></div>
+  <aside>Comment on my image</aside>
+</template>
 ```
 
 ### Methods
@@ -237,13 +256,13 @@ Specifies the high definition image to show on zoom. This image is loaded when t
 
 ### Events
 
-| Event            | Description                                                         |
-|------------------|---------------------------------------------------------------------|
-| show             | Fired immediately when the `show` instance method is called         |
-| shown            | Fired when the zoom has finished being animated                     |
-| hide             | Fired immediately when the `hide` instance method is called         |
-| hidden           | Fired when the zoom out has finished being animated                 |
-| detach           | Fired when the `detach` instance method is called                   |
+| Event  | Description                                                 |
+|--------|-------------------------------------------------------------|
+| show   | Fired immediately when the `show` instance method is called |
+| shown  | Fired when the zoom has finished being animated             |
+| hide   | Fired immediately when the `hide` instance method is called |
+| hidden | Fired when the zoom out has finished being animated         |
+| detach | Fired when the `detach` instance method is called           |
 
 ```js
 const zoom = mediumZoom('#image-tracked')

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 * 🖱 **Mouse, keyboard and gesture friendly** — *click anywhere, press a key or scroll away to dismiss the zoom*
 * 🎉 **Event handling** — *trigger events when the zoom enters a new state*
 * 🔧 **Customization** — *set your own margin, background and scroll offset*
-* 💎 **Custom renderer** — *extend the default look to match your UI*
+* 💎 **Custom templates** — *extend the default look to match your UI*
 * 🔗 **Link support** — *open the link of the image in a new tab when a meta key is held (<kbd>⌘</kbd> or <kbd>Ctrl</kbd>)*
 * 🖼 **Image opener** — *when no link, open the image source in a new tab when a meta key is held (<kbd>⌘</kbd> or <kbd>Ctrl</kbd>)*
 
@@ -135,13 +135,14 @@ mediumZoom(imagesToZoom)
 
 Options can be passed via a JavaScript object through the `mediumZoom` call.
 
-| Properties   | Type    | Default  | Description                                                         |
-|--------------|---------|----------|---------------------------------------------------------------------|
-| `margin`       | integer | `0`      | Space outside the zoomed image                                      |
-| `background`   | string  | `"#fff"` | Color of the overlay                                                |
-| `scrollOffset` | integer | `48`     | Number of pixels to scroll to dismiss the zoom                      |
-| `metaClick`    | boolean | `true`   | Enables the action on [meta click](https://en.wikipedia.org/wiki/Meta_key) (opens the link / image source)    |
-| `container`    | string \| Element | `undefined`   | [Template element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) to render the zoomed image in |
+| Property       | Type                        | Default  | Description                                                                                                |
+|----------------|-----------------------------|----------|------------------------------------------------------------------------------------------------------------|
+| `margin`       | `number`                    | `0`      | The space outside the zoomed image                                                                         |
+| `background`   | `string`                    | `"#fff"` | The color of the overlay                                                                                   |
+| `scrollOffset` | `number`                    | `48`     | The number of pixels to scroll to dismiss the zoom                                                         |
+| `metaClick`    | `boolean`                   | `true`   | Enables the action on [meta click](https://en.wikipedia.org/wiki/Meta_key) (opens the link / image source) |
+| `container`    | `string`/`Element`/`object` |          | The element to render the zoom in or a viewport object. [Read more →](#using-a-custom-container)           |
+| `template`     | `string`/`Element`          |          | The template element to show on zoom. [Read more →](#using-a-custom-template)                              |
 
 ```js
 mediumZoom('[data-action="zoom"]', {
@@ -149,23 +150,75 @@ mediumZoom('[data-action="zoom"]', {
   background: '#000',
   scrollOffset: 0,
   metaClick: false,
-  container: '#zoom-container'
+  container: '[data-zoom-container]',
+  template: '#zoom-template',
 })
 ```
 
 #### Using a custom `container`
 
-You might want to render the zoom in your own container. You could reproduce zooms as seen on Facebook or Dropbox Paper. This is possible with the `container` option.
+The zoom is by default rendered in the window viewport. You can also render your image in any element of the DOM, or any custom coordinates with the `container` option.
 
-1. Create a `template` element matching the `container` option value
-2. If you'd like your image to appear at a specific location in your template, specify the `data-zoom-container` attribute on the element
+##### Rendering in a DOM Element
 
 ```html
-<template id="zoom-container">
-  <header>My image zoom template</header>
-  <div data-zoom-container></div>
-  <aside>Comment on my image</aside>
+<article>
+  <p>My article...</p>
+  <img src="image.jpg" alt="My image">
+  <div data-zoom-container>
+</article>
+
+<script>
+  mediumZoom('img', {
+    container: '[data-zoom-container]' // or document.querySelector('[data-zoom-container]')
+  })
+</script>
+```
+
+##### Rendering with coordinates
+
+If you don't already have an element in your DOM to specify the position of the zoom, you can pass an object with the following `number` properties:
+
+```js
+
+mediumZoom('img', {
+  container: {
+    width: 720,
+    height: 480,
+    top: 64,
+    bottom: 64,
+    right: 0,
+    left: 0
+  }
+})
+```
+
+These properties behave very much like [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect). They will get merged with the default ones so you don't need to specify all of them.
+
+The default `width` and `height` are `window.innerWidth` and `window.innerHeight`. Others are set to `0`.
+
+#### Using a custom `template`
+
+You might want to render the zoom in your own template. You could reproduce zooms as seen on Facebook or Dropbox Paper. This is possible with the `template` option.
+
+1. Create a [`template`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element matching the `template` option value
+2. If you'd like your image to appear at a specific position in your template, specify the `container` option and add it in your template (`data-zoom-container` here)
+
+```html
+<template id="zoom-template">
+  <div>
+    <header>My image zoom template</header>
+    <div data-zoom-container></div>
+    <aside>Comment on my image</aside>
+  </div>
 </template>
+
+<script>
+  mediumZoom('[data-action="zoom"]', {
+    template: '#zoom-template',
+    container: '[data-zoom-container]'
+  })
+</script>
 ```
 
 ### Methods

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ mediumZoom('[data-action="zoom"]', {
   scrollOffset: 0,
   metaClick: false,
   container: '[data-zoom-container]',
-  template: '#zoom-template',
+  template: '#zoom-template'
 })
 ```
 

--- a/__tests__/__snapshots__/medium-zoom-test.js.snap
+++ b/__tests__/__snapshots__/medium-zoom-test.js.snap
@@ -36,7 +36,45 @@ exports[`show renders correctly 1`] = `
 </body>
 `;
 
-exports[`show renders correctly with container as a Node 1`] = `
+exports[`show renders correctly with background option 1`] = `
+<body>
+  <img
+    class="medium-zoom-image"
+    style="visibility: hidden;"
+  />
+  <div
+    class="medium-zoom-overlay"
+    style="background-color: rgb(186, 218, 85);"
+  />
+  <img
+    class="medium-zoom-image medium-zoom-image--open"
+    style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"
+  />
+</body>
+`;
+
+exports[`show renders correctly with template option as a string 1`] = `
+<body>
+  <template
+    id="zoom-template"
+  />
+  <img
+    class="medium-zoom-image"
+    style="visibility: hidden;"
+  />
+  <div
+    class="medium-zoom-overlay"
+    style="background-color: rgb(255, 255, 255);"
+  />
+  <div />
+  <img
+    class="medium-zoom-image medium-zoom-image--open"
+    style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"
+  />
+</body>
+`;
+
+exports[`show renders correctly with template option as an HTML Element 1`] = `
 <body>
   <template />
   <img
@@ -48,44 +86,6 @@ exports[`show renders correctly with container as a Node 1`] = `
     style="background-color: rgb(255, 255, 255);"
   />
   <div />
-  <img
-    class="medium-zoom-image medium-zoom-image--open"
-    style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"
-  />
-</body>
-`;
-
-exports[`show renders correctly with container as a string 1`] = `
-<body>
-  <template
-    id="zoom-container"
-  />
-  <img
-    class="medium-zoom-image"
-    style="visibility: hidden;"
-  />
-  <div
-    class="medium-zoom-overlay"
-    style="background-color: rgb(255, 255, 255);"
-  />
-  <div />
-  <img
-    class="medium-zoom-image medium-zoom-image--open"
-    style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"
-  />
-</body>
-`;
-
-exports[`show renders correctly with options overlay background 1`] = `
-<body>
-  <img
-    class="medium-zoom-image"
-    style="visibility: hidden;"
-  />
-  <div
-    class="medium-zoom-overlay"
-    style="background-color: rgb(186, 218, 85);"
-  />
   <img
     class="medium-zoom-image medium-zoom-image--open"
     style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"

--- a/__tests__/__snapshots__/medium-zoom-test.js.snap
+++ b/__tests__/__snapshots__/medium-zoom-test.js.snap
@@ -36,6 +36,46 @@ exports[`show renders correctly 1`] = `
 </body>
 `;
 
+exports[`show renders correctly with container as a Node 1`] = `
+<body>
+  <template />
+  <img
+    class="medium-zoom-image"
+    style="visibility: hidden;"
+  />
+  <div
+    class="medium-zoom-overlay"
+    style="background-color: rgb(255, 255, 255);"
+  />
+  <div />
+  <img
+    class="medium-zoom-image medium-zoom-image--open"
+    style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"
+  />
+</body>
+`;
+
+exports[`show renders correctly with container as a string 1`] = `
+<body>
+  <template
+    id="zoom-container"
+  />
+  <img
+    class="medium-zoom-image"
+    style="visibility: hidden;"
+  />
+  <div
+    class="medium-zoom-overlay"
+    style="background-color: rgb(255, 255, 255);"
+  />
+  <div />
+  <img
+    class="medium-zoom-image medium-zoom-image--open"
+    style="position: absolute; top: 0px; left: 0px; width: 0px; height: 0px;"
+  />
+</body>
+`;
+
 exports[`show renders correctly with options overlay background 1`] = `
 <body>
   <img

--- a/__tests__/medium-zoom-test.js
+++ b/__tests__/medium-zoom-test.js
@@ -303,6 +303,35 @@ describe('show', () => {
 
     expect(root).toMatchSnapshot()
   })
+
+  test('renders correctly with container as a Node', () => {
+    const container = document.createElement('template')
+    const image = document.createElement('img')
+    root.appendChild(container)
+    root.appendChild(image)
+
+    const zoom = mediumZoom('img', {
+      container
+    })
+    zoom.show()
+
+    expect(root).toMatchSnapshot()
+  })
+
+  test('renders correctly with container as a string', () => {
+    const container = document.createElement('template')
+    container.id = 'zoom-container'
+    const image = document.createElement('img')
+    root.appendChild(container)
+    root.appendChild(image)
+
+    const zoom = mediumZoom('img', {
+      container: '#zoom-container'
+    })
+    zoom.show()
+
+    expect(root).toMatchSnapshot()
+  })
 })
 
 describe('hide', () => {

--- a/__tests__/medium-zoom-test.js
+++ b/__tests__/medium-zoom-test.js
@@ -261,6 +261,66 @@ describe('update', () => {
     expect(zoom.options).toEqual(expected)
   })
 
+  test('with container as an Element updates the container option and returns all options', () => {
+    const zoom = mediumZoom()
+    const options = zoom.update({
+      container: document.body
+    })
+    const expected = {
+      margin: 0,
+      background: '#fff',
+      scrollOffset: 48,
+      metaClick: true,
+      container: document.body
+    }
+
+    expect(options).toEqual(expected)
+    expect(zoom.options).toEqual(expected)
+  })
+
+  test('with container as a string updates the container option and returns all options', () => {
+    const zoom = mediumZoom()
+    const options = zoom.update({
+      container: 'body'
+    })
+    const expected = {
+      margin: 0,
+      background: '#fff',
+      scrollOffset: 48,
+      metaClick: true,
+      container: 'body'
+    }
+
+    expect(options).toEqual(expected)
+    expect(zoom.options).toEqual(expected)
+  })
+
+  test('with container as an object updates the container option and returns all options', () => {
+    const zoom = mediumZoom({
+      container: {
+        top: 64
+      }
+    })
+    const options = zoom.update({
+      container: {
+        left: 64
+      }
+    })
+    const expected = {
+      margin: 0,
+      background: '#fff',
+      scrollOffset: 48,
+      metaClick: true,
+      container: {
+        top: 64,
+        left: 64
+      }
+    }
+
+    expect(options).toEqual(expected)
+    expect(zoom.options).toEqual(expected)
+  })
+
   test('with all options updates all options and returns all options', () => {
     const expected = {
       margin: 24,
@@ -292,7 +352,7 @@ describe('show', () => {
     expect(root).toMatchSnapshot()
   })
 
-  test('renders correctly with options overlay background', () => {
+  test('renders correctly with background option', () => {
     const image = document.createElement('img')
     root.appendChild(image)
 
@@ -304,29 +364,29 @@ describe('show', () => {
     expect(root).toMatchSnapshot()
   })
 
-  test('renders correctly with container as a Node', () => {
-    const container = document.createElement('template')
+  test('renders correctly with template option as an HTML Element', () => {
+    const template = document.createElement('template')
     const image = document.createElement('img')
-    root.appendChild(container)
+    root.appendChild(template)
     root.appendChild(image)
 
     const zoom = mediumZoom('img', {
-      container
+      template
     })
     zoom.show()
 
     expect(root).toMatchSnapshot()
   })
 
-  test('renders correctly with container as a string', () => {
-    const container = document.createElement('template')
-    container.id = 'zoom-container'
+  test('renders correctly with template option as a string', () => {
+    const template = document.createElement('template')
+    template.id = 'zoom-template'
     const image = document.createElement('img')
-    root.appendChild(container)
+    root.appendChild(template)
     root.appendChild(image)
 
     const zoom = mediumZoom('img', {
-      container: '#zoom-container'
+      template: '#zoom-template'
     })
     zoom.show()
 

--- a/examples/javascript/preview/container.html
+++ b/examples/javascript/preview/container.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#00ab6c">
+
+    <link rel="shortcut icon" href="../favicon.ico">
+
+    <link href="https://fonts.googleapis.com/css?family=Varela+Round|Work+Sans" rel="stylesheet">
+    <link href="../reset.css" rel="stylesheet">
+    <link href="../style.css" rel="stylesheet">
+
+    <title>Medium Zoom | Demo</title>
+
+    <style>
+      .paper-wrapper {
+        position: fixed;
+        display: flex;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100vh;
+      }
+      .facebook-wrapper {
+        position: fixed;
+        display: flex;
+        top: 4rem;
+        left: 4rem;
+        right: 4rem;
+        bottom: 4rem;
+      }
+      .container-main {
+        flex: 3;
+        height: 100%;
+      }
+      .container-main_dark {
+        background-color: #000;
+      }
+      .container-header {
+        padding: 16px;
+      }
+      .container-close {
+        width: 24px;
+        cursor: pointer;
+        fill: #637282;
+      }
+      .container-aside {
+        width: 300px;
+        padding: 24px;
+        flex: 1;
+        border-left: 1px solid #e6e8eb;
+        background-color: #fff;
+      }
+      .container-aside__title {
+        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,sans-serif;
+        color: #637282;
+      }
+      .container-aside__content {
+        font-size: .9rem; padding-top: 1rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <header class="header">
+      <h1 class="header__title">Medium Zoom</h1>
+      <div class="header__subtitle">Medium zoom on your images in vanilla JavaScript</div>
+
+      <div class="header__info">
+        <a href="https://github.com/francoischalifour/medium-zoom" class="button">View on GitHub</a>
+        <a href="https://francoischalifour.com/lab/medium-image-zoom" class="button">Read the article</a>
+      </div>
+    </header>
+
+    <article class="container">
+
+      <template id="template-paper">
+        <div class="paper-wrapper">
+          <section class="container-main" data-zoom-container>
+            <header class="container-header">
+              <svg class="container-close" data-zoom-close viewBox="0 0 24 24">
+                <path d="M8.817 7.403a1 1 0 0 0-1.414 1.414L10.586 12l-3.183 3.183a1 1 0 0 0 1.414 1.415L12 13.415l3.183 3.183a1 1 0 0 0 1.415-1.415L13.415 12l3.183-3.183a1 1 0 0 0-1.415-1.414L12 10.586 8.817 7.403z" fill-rule="evenodd"></path>
+              </svg>
+            </header>
+          </section>
+          <aside class="container-aside">
+            <h3 class="container-aside__title">Comments</h3>
+            <p class="container-aside__content">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Tempora praesentium cupiditate fugit voluptas.
+            </p>
+          </aside>
+        </div>
+      </template>
+
+      <template id="template-facebook">
+        <div class="facebook-wrapper">
+          <section class="container-main container-main_dark" data-zoom-container>
+            <header style="float:right; padding: 16px;">
+              <svg class="container-close" data-zoom-close viewBox="0 0 24 24">
+                <path d="M8.817 7.403a1 1 0 0 0-1.414 1.414L10.586 12l-3.183 3.183a1 1 0 0 0 1.414 1.415L12 13.415l3.183 3.183a1 1 0 0 0 1.415-1.415L13.415 12l3.183-3.183a1 1 0 0 0-1.415-1.414L12 10.586 8.817 7.403z" fill-rule="evenodd"></path>
+              </svg>
+            </header>
+          </section>
+          <aside class="container-aside">
+            <h3 class="container-aside__title">Comments</h3>
+            <p class="container-aside__content">
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+              Tempora praesentium cupiditate fugit voluptas.
+            </p>
+          </aside>
+        </div>
+      </template>
+
+      <figure>
+        <img
+          class="zoom-paper"
+          src="../images/image-2.jpg"
+          alt="Zoom with Paper style"
+        >
+        <figcaption>Zoom with Paper style</figcaption>
+      </figure>
+
+      <figure>
+        <img
+          class="zoom-paper"
+          src="../images/image-3.jpg"
+          alt="Zoom with Paper style"
+        >
+        <figcaption>Zoom with Paper style #2</figcaption>
+      </figure>
+
+      <figure>
+        <img
+          id="zoom-facebook"
+          src="../images/image-6.jpg"
+          alt="Zoom with Facebook style"
+        >
+        <figcaption>Zoom with Facebook style</figcaption>
+      </figure>
+
+    </article>
+
+    <footer class="footer">
+      <div class="footer__links">
+        <a href="https://github.com/francoischalifour/medium-zoom" class="button">View on GitHub</a>
+        <a href="http://francoischalifour.com/lab/medium-image-zoom" class="button">Read the article</a>
+      </div>
+
+      <div class="footer__copyright">
+        Made by <a href="https://francoischalifour.com">François Chalifour</a>
+      </div>
+
+      <p><a href="#">Back to top</a></p>
+    </footer>
+
+    <script src="medium-zoom.min.js"></script>
+    <script>
+      console.info('You\'re in preview environment 🖥')
+
+      const zoomPaper = mediumZoom('.zoom-paper', {
+        background: 'rgba(247,249,250,0.97)',
+        margin: 24,
+        container: '#template-paper'
+      })
+
+      // You can start manipulating the DOM after the `shown` event has been triggered
+      zoomPaper.addEventListeners('shown', () => {
+        const closeButton = document.querySelector('[data-zoom-close]')
+        closeButton.addEventListener('click', () => zoomPaper.hide())
+      })
+
+      const zoomFacebook = mediumZoom('#zoom-facebook', {
+        background: 'rgba(0,0,0,0.9)',
+        container: document.querySelector('#template-facebook')
+      })
+
+      // Block scroll on zoom
+      zoomFacebook.addEventListeners('show', () => {
+        document.body.style.overflow = 'hidden'
+      })
+
+      zoomFacebook.addEventListeners('hide', () => {
+        document.body.style.overflow = ''
+      })
+
+      zoomFacebook.addEventListeners('shown', () => {
+        const closeButton = document.querySelector('[data-zoom-close]')
+        closeButton.addEventListener('click', () => zoomFacebook.hide())
+      })
+    </script>
+  </body>
+</html>

--- a/examples/javascript/preview/container.html
+++ b/examples/javascript/preview/container.html
@@ -24,8 +24,8 @@
         font-family: 'AtlasGrotesk-dmc', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
       }
       .paper-container {
-        height: calc(100% - 80px);
-        width: calc(100% - 32px);
+        width: 100%;
+        height: calc(100% - 64px);
         margin: 0 auto;
       }
       .paper-header {
@@ -198,6 +198,15 @@
         <figcaption>Zoom with Facebook style #2</figcaption>
       </figure>
 
+      <figure>
+        <img
+          class="zoom-header"
+          src="../images/image-6.jpg"
+          alt="Zoom with space for header"
+        >
+        <figcaption>Zoom with space for header</figcaption>
+      </figure>
+
     </article>
 
     <footer class="footer">
@@ -219,7 +228,9 @@
 
       const zoomPaper = mediumZoom('.zoom-paper', {
         background: 'rgba(247,249,250,0.97)',
-        container: '#template-paper'
+        margin: 16,
+        template: '#template-paper',
+        container: '[data-zoom-container]'
       })
 
       // You can start manipulating the DOM after the `shown` event has been triggered
@@ -237,7 +248,8 @@
 
       const zoomFacebook = mediumZoom('.zoom-facebook', {
         background: 'rgba(0,0,0,0.9)',
-        container: document.querySelector('#template-facebook')
+        template: document.querySelector('#template-facebook'),
+        container: '[data-zoom-container]'
       })
 
       // Block scroll on zoom
@@ -252,6 +264,12 @@
       zoomFacebook.addEventListeners('shown', () => {
         const closeButton = document.querySelector('[data-zoom-close]')
         closeButton.addEventListener('click', () => zoomFacebook.hide())
+      })
+
+      const zoomTopHeader = mediumZoom('.zoom-header', {
+        container: {
+          top: 64
+        }
       })
     </script>
   </body>

--- a/examples/javascript/preview/container.html
+++ b/examples/javascript/preview/container.html
@@ -21,43 +21,99 @@
         left: 0;
         width: 100%;
         height: 100vh;
+        font-family: 'AtlasGrotesk-dmc', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
       }
-      .facebook-wrapper {
-        position: fixed;
+      .paper-container {
+        height: calc(100% - 80px);
+        width: calc(100% - 32px);
+        margin: 0 auto;
+      }
+      .paper-header {
         display: flex;
-        top: 4rem;
-        left: 4rem;
-        right: 4rem;
-        bottom: 4rem;
-      }
-      .container-main {
-        flex: 3;
-        height: 100%;
-      }
-      .container-main_dark {
-        background-color: #000;
-      }
-      .container-header {
+        align-items: center;
+        height: 64px;
         padding: 16px;
       }
-      .container-close {
+      .paper-main {
+        flex: 1;
+        height: 100%;
+      }
+      .paper-close {
         width: 24px;
         cursor: pointer;
         fill: #637282;
       }
-      .container-aside {
-        width: 300px;
-        padding: 24px;
-        flex: 1;
+      .paper-sidebar {
+        width: 290px;
         border-left: 1px solid #e6e8eb;
         background-color: #fff;
+        padding: 32px 0 16px 0;
       }
-      .container-aside__title {
-        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,sans-serif;
+      @media (max-width: 800px) {
+        .paper-sidebar {
+          display: none;
+        }
+      }
+      .paper-sidebar__header,
+      .paper-sidebar__content {
+        padding: 16px;
+      }
+      .paper-sidebar__header {
+        border-bottom: 1px solid #e6e8eb;
+      }
+      .paper-sidebar__textarea {
+        outline: none;
+        width: 100%;
+        border: none;
+        background: none;
+        font: inherit;
+        font-size: .9rem;
         color: #637282;
       }
-      .container-aside__content {
-        font-size: .9rem; padding-top: 1rem;
+      .paper-sidebar__textarea::placeholder {
+        color: #c1c7cd;
+      }
+      .paper-sidebar__textarea_comment {
+        width: 100%;
+        padding: 16px;
+        border-radius: 5px;
+        border: 1px solid rgba(99,114,130,0.4);
+      }
+
+      .facebook-wrapper {
+        position: fixed;
+        display: flex;
+        top: 0;
+        height: 520px;
+        top: 0;
+        bottom: 0;
+        left: 4rem;
+        right: 4rem;
+        margin: auto;
+        box-shadow: 0 12px 24px rgba(0,0,0,.3);
+      }
+      .facebook-main {
+        flex: 1;
+        height: 100%;
+        background-color: #000;
+      }
+      .facebook-sidebar {
+        width: 360px;
+        background-color: #fff;
+        padding: 32px 0 16px 0;
+      }
+      @media (max-width: 800px) {
+        .facebook-sidebar {
+          display: none;
+        }
+      }
+      .facebook-close {
+        position: fixed;
+        top: 8px;
+        right: 8px;
+        width: 32px;
+        cursor: pointer;
+        fill: #ddd;
       }
     </style>
   </head>
@@ -77,46 +133,39 @@
 
       <template id="template-paper">
         <div class="paper-wrapper">
-          <section class="container-main" data-zoom-container>
-            <header class="container-header">
-              <svg class="container-close" data-zoom-close viewBox="0 0 24 24">
+          <section class="paper-main" data-zoom-close>
+            <header class="paper-header">
+              <svg class="paper-close" data-zoom-close viewBox="0 0 24 24">
                 <path d="M8.817 7.403a1 1 0 0 0-1.414 1.414L10.586 12l-3.183 3.183a1 1 0 0 0 1.414 1.415L12 13.415l3.183 3.183a1 1 0 0 0 1.415-1.415L13.415 12l3.183-3.183a1 1 0 0 0-1.415-1.414L12 10.586 8.817 7.403z" fill-rule="evenodd"></path>
               </svg>
             </header>
+            <div class="paper-container" data-zoom-container></div>
           </section>
-          <aside class="container-aside">
-            <h3 class="container-aside__title">Comments</h3>
-            <p class="container-aside__content">
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-              Tempora praesentium cupiditate fugit voluptas.
-            </p>
+          <aside class="paper-sidebar">
+            <header class="paper-sidebar__header">
+              <textarea class="paper-sidebar__textarea" rows="1" placeholder="Write a caption"></textarea>
+            </header>
+            <section class="paper-sidebar__content">
+              <textarea class="paper-sidebar__textarea paper-sidebar__textarea_comment" rows="1" placeholder="New comment"></textarea>
+            </section>
           </aside>
         </div>
       </template>
 
       <template id="template-facebook">
         <div class="facebook-wrapper">
-          <section class="container-main container-main_dark" data-zoom-container>
-            <header style="float:right; padding: 16px;">
-              <svg class="container-close" data-zoom-close viewBox="0 0 24 24">
-                <path d="M8.817 7.403a1 1 0 0 0-1.414 1.414L10.586 12l-3.183 3.183a1 1 0 0 0 1.414 1.415L12 13.415l3.183 3.183a1 1 0 0 0 1.415-1.415L13.415 12l3.183-3.183a1 1 0 0 0-1.415-1.414L12 10.586 8.817 7.403z" fill-rule="evenodd"></path>
-              </svg>
-            </header>
-          </section>
-          <aside class="container-aside">
-            <h3 class="container-aside__title">Comments</h3>
-            <p class="container-aside__content">
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-              Tempora praesentium cupiditate fugit voluptas.
-            </p>
-          </aside>
+          <svg class="facebook-close" data-zoom-close viewBox="0 0 24 24">
+            <path d="M8.817 7.403a1 1 0 0 0-1.414 1.414L10.586 12l-3.183 3.183a1 1 0 0 0 1.414 1.415L12 13.415l3.183 3.183a1 1 0 0 0 1.415-1.415L13.415 12l3.183-3.183a1 1 0 0 0-1.415-1.414L12 10.586 8.817 7.403z" fill-rule="evenodd"></path>
+          </svg>
+          <section class="facebook-main" data-zoom-container></section>
+          <aside class="facebook-sidebar"></aside>
         </div>
       </template>
 
       <figure>
         <img
           class="zoom-paper"
-          src="../images/image-2.jpg"
+          src="../images/image-1.jpg"
           alt="Zoom with Paper style"
         >
         <figcaption>Zoom with Paper style</figcaption>
@@ -133,11 +182,20 @@
 
       <figure>
         <img
-          id="zoom-facebook"
+          class="zoom-facebook"
           src="../images/image-6.jpg"
           alt="Zoom with Facebook style"
         >
         <figcaption>Zoom with Facebook style</figcaption>
+      </figure>
+
+      <figure>
+        <img
+          class="zoom-facebook"
+          src="../images/image-5.jpg"
+          alt="Zoom with Facebook style"
+        >
+        <figcaption>Zoom with Facebook style #2</figcaption>
       </figure>
 
     </article>
@@ -161,7 +219,6 @@
 
       const zoomPaper = mediumZoom('.zoom-paper', {
         background: 'rgba(247,249,250,0.97)',
-        margin: 24,
         container: '#template-paper'
       })
 
@@ -170,8 +227,15 @@
         const closeButton = document.querySelector('[data-zoom-close]')
         closeButton.addEventListener('click', () => zoomPaper.hide())
       })
+      // Block scroll on zoom
+      zoomPaper.addEventListeners('show', () => {
+        document.body.style.overflow = 'hidden'
+      })
+      zoomPaper.addEventListeners('hide', () => {
+        document.body.style.overflow = ''
+      })
 
-      const zoomFacebook = mediumZoom('#zoom-facebook', {
+      const zoomFacebook = mediumZoom('.zoom-facebook', {
         background: 'rgba(0,0,0,0.9)',
         container: document.querySelector('#template-facebook')
       })

--- a/src/medium-zoom.css
+++ b/src/medium-zoom.css
@@ -23,7 +23,6 @@
 
 .medium-zoom-image--open {
   position: relative;
-  z-index: 999;
   cursor: pointer;
   cursor: zoom-out;
   will-change: transform;

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -170,8 +170,13 @@ const mediumZoom = (selector, {
   }
 
   const triggerZoom = event => {
-    if (!target.template) {
-      target.template = event ? event.target : images[0]
+    if (event && event.target) {
+      // The zoom was triggered manually via a click
+      target.original = event.target
+      zoom()
+    } else if (!target.original) {
+      // The zoom was triggered programmatically, select the first image in the list
+      target.original = images[0]
       zoom()
     } else {
       zoomOut()


### PR DESCRIPTION
Following the discussion in #23, I decided to add support for custom containers. I believe this is a really useful feature to reproduce any UI you want, extending Medium's default style.

### How to use

```html
<!-- Add the custom template as an HTML template -->
<template id="template-paper">
  <div class="paper-wrapper">
    <section class="container-main" data-zoom-container>
      <header class="container-header">
        <svg class="container-close" data-zoom-close viewBox="0 0 24 24">
          <path d="M8.817 7.403a1 1 0 0 0-1.414 1.414L10.586 12l-3.183 3.183a1 1 0 0 0 1.414 1.415L12 13.415l3.183 3.183a1 1 0 0 0 1.415-1.415L13.415 12l3.183-3.183a1 1 0 0 0-1.415-1.414L12 10.586 8.817 7.403z" fill-rule="evenodd"></path>
        </svg>
      </header>
    </section>
    <aside class="container-aside">
      <h3 class="container-aside__title">Comments</h3>
      <p class="container-aside__content">
        Lorem ipsum dolor sit amet, consectetur adipisicing elit.
        Tempora praesentium cupiditate fugit voluptas.
      </p>
    </aside>
  </div>
</template>

<!-- Add your image -->
<figure>
  <img
    class="zoom-paper"
    src="../images/image-2.jpg"
    alt="Zoom with Paper style"
  >
  <figcaption>Zoom with Paper style</figcaption>
</figure>

<!-- Call medium-zoom specifying the `template` and `container` -->
<script>
  mediumZoom('.zoom-paper', {
    background: 'rgba(247,249,250,0.97)',
    margin: 24,
    template: '#template-paper',
    container: '[data-zoom-container]'
  })
</script>
```

### Demo

**[See preview](https://deploy-preview-25--medium-zoom.netlify.com/preview/container.html)**

### Examples

#### Dropbox Paper

![medium-zoom-paper](https://user-images.githubusercontent.com/6137112/31954488-be27c18a-b8b3-11e7-81b0-1620cc99d631.gif)

#### Facebook

![medium-zoom-facebook](https://user-images.githubusercontent.com/6137112/31975184-6c93b6cc-b8fd-11e7-9cce-64461996195e.gif)