### PR TITLE
Fix for overflow when scrollbars are visible.

### DIFF
--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -268,8 +268,8 @@ const mediumZoom = (selector, options = {}) => {
   const open = ({ target } = {}) => {
     const _animate = () => {
       let container = {
-        width: window.innerWidth,
-        height: window.innerHeight,
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight,
         left: 0,
         top: 0,
         right: 0,


### PR DESCRIPTION
Closes #75.

## Summary

Fixes issue where scrollbars are visible but not accounted for in the measured width.

## Result

Changes as suggested.

NB - I'm not convinced this works correctly for vertical positioning on iOS Safari. But I'm also not convinced the _existing_ solution works there either.