### PR TITLE
Export mediumZoom correctly as ESM style

### DIFF
--- a/src/medium-zoom.d.ts
+++ b/src/medium-zoom.d.ts
@@ -175,4 +175,4 @@ declare function mediumZoom(
  */
 declare function mediumZoom(options?: ZoomOptions): Zoom
 
-export = mediumZoom
+export default mediumZoom


### PR DESCRIPTION
## Summary

This PR fixes this compile error on TypeScript 3.x.

![image](https://user-images.githubusercontent.com/85887/50571950-0b138080-0d6b-11e9-818a-ee0685c39637.png)

The actual exporting of `mediumZoom` is taking ESM way since last August.
https://github.com/francoischalifour/medium-zoom/blob/master/src/index.js#L4

TS expects the same way for typedefs.

### `export = Something` on TS

https://www.typescriptlang.org/docs/handbook/modules.html

> When exporting a module using export =, TypeScript-specific import module = require("module") must be used to import the module.