### PR TITLE
chore(scripts): add script to update examples

### DIFF
--- a/scripts/update-examples.js
+++ b/scripts/update-examples.js
@@ -1,0 +1,14 @@
+const { readdirSync, statSync } = require('fs')
+const { join } = require('path')
+const { execSync } = require('child_process')
+const { version } = require('../package.json')
+
+const examples = readdirSync('examples')
+  .map(file => join('examples', file))
+  .filter(file => statSync(file).isDirectory())
+
+examples.forEach(path => {
+  execSync(`cd ${path} && yarn upgrade medium-zoom@${version}`, {
+    stdio: 'inherit',
+  })
+})


### PR DESCRIPTION
This script updates all the examples to the `medium-zoom` version specified in `package.json`. This is meant to be run after a release (handled in another PR).