### PR TITLE
fix: do not use window outside main function (close #94)

### DIFF
--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -98,17 +98,17 @@ const createCustomEvent = (type, params) => {
   return customEvent
 }
 
-/**
- * Ensure the compatibility with IE11 if no Promise polyfill are used.
- */
-const Promise =
-  window.Promise ||
-  function Promise(fn) {
-    function noop() {}
-    fn(noop, noop)
-  }
-
 const mediumZoom = (selector, options = {}) => {
+  /**
+   * Ensure the compatibility with IE11 if no Promise polyfill are used.
+   */
+  const Promise =
+    window.Promise ||
+    function Promise(fn) {
+      function noop() {}
+      fn(noop, noop)
+    }
+
   const _handleClick = event => {
     const { target } = event
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request 🙌
  This template helps you create an effective feature report.
-->

## Summary

<!-- Explain why you are making this change and link related issues (#ISSUE_NUMBER) -->

Related to #94

- move `const Promise = ...` into `mediumZoom()` to avoid accessing `window` immediately
