### PR TITLE
fix: support lazy loading images on Firefox

### DIFF
--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -379,6 +379,10 @@ const mediumZoom = (selector, options = {}) => {
         // image best fitting the current viewport size, respecting the `srcset`.
         active.zoomedHd.removeAttribute('sizes')
 
+        // In Firefox, the `loading` attribute needs to be set to `eager` for the
+        // load event to be fired.
+        active.zoomedHd.setAttribute('loading', 'eager')
+
         // Wait for the load event of the hd image. This will fire if the image
         // is already cached.
         const loadEventListener = active.zoomedHd.addEventListener(

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -379,9 +379,9 @@ const mediumZoom = (selector, options = {}) => {
         // image best fitting the current viewport size, respecting the `srcset`.
         active.zoomedHd.removeAttribute('sizes')
 
-        // In Firefox, the `loading` attribute needs to be set to `eager` for the
-        // load event to be fired.
-        active.zoomedHd.setAttribute('loading', 'eager')
+        // In Firefox, the `loading` attribute needs to be set to `eager` (default
+        // value) for the load event to be fired.
+        active.zoomedHd.setAttribute('loading', '')
 
         // Wait for the load event of the hd image. This will fire if the image
         // is already cached.


### PR DESCRIPTION
## Summary

Fixes https://github.com/francoischalifour/medium-zoom/issues/157.

## Result

The image is correctly zoomed even with the `loading` attribute set to `lazy`.