### PR TITLE
fix mobile safari scale bug

### DIFF
--- a/src/medium-zoom.css
+++ b/src/medium-zoom.css
@@ -27,7 +27,9 @@
 
     See https://github.com/francoischalifour/medium-zoom/issues/110
    */
-  transition: transform 300ms cubic-bezier(0.2, 0, 0.2, 1) !important;
+  transition: transform 300ms cubic-bezier(0.2, 0, 0.2, 1),
+    width 300ms cubic-bezier(0.2, 0, 0.2, 1),
+    height 300ms cubic-bezier(0.2, 0, 0.2, 1) !important;
 }
 
 .medium-zoom-image--hidden {
@@ -38,5 +40,5 @@
   position: relative;
   cursor: pointer;
   cursor: zoom-out;
-  will-change: transform;
+  will-change: transform, width;;
 }

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -246,20 +246,21 @@ const mediumZoom = (selector, options = {}) => {
 
       const scaleX = Math.min(naturalWidth, viewportWidth) / width
       const scaleY = Math.min(naturalHeight, viewportHeight) / height
-      const scale = Math.min(scaleX, scaleY)
+      const scale = Math.min(scaleX, scaleY);
+      active.zoomed.style.width = `${width * scale}px`;
+      active.zoomed.style.height = `${height * scale}px`;
+
       const translateX =
-        (-left +
-          (viewportWidth - width) / 2 +
-          zoomOptions.margin +
-          container.left) /
-        scale
+        -left +
+        (viewportWidth - width * scale) / 2 +
+        zoomOptions.margin +
+        container.left;
       const translateY =
-        (-top +
-          (viewportHeight - height) / 2 +
-          zoomOptions.margin +
-          container.top) /
-        scale
-      const transform = `scale(${scale}) translate3d(${translateX}px, ${translateY}px, 0)`
+        -top +
+        (viewportHeight / scale - height) / 2 +
+        zoomOptions.margin +
+        container.top;
+      const transform = `translate3d(${translateX}px, ${translateY}px, 0)`;
 
       active.zoomed.style.transform = transform
 
@@ -446,6 +447,11 @@ const mediumZoom = (selector, options = {}) => {
       isAnimating = true
       document.body.classList.remove('medium-zoom--opened')
       active.zoomed.style.transform = ''
+
+      const zoomTarget = active.zoomedHd || active.original;
+      const { width, height } = zoomTarget.getBoundingClientRect();
+      active.zoomed.style.width = `${width}px`;
+      active.zoomed.style.height = `${height}px`;
 
       if (active.zoomedHd) {
         active.zoomedHd.style.transform = ''


### PR DESCRIPTION
## Summary

<!-- Explain why you are making this change and link related issues (#ISSUE_NUMBER) -->
fixed this issue on mobile safari zoomed image blurry. #151
https://github.com/francoischalifour/medium-zoom/issues/151

## Result

<!-- Explain what you've changed and what's the result! -->

It does not use "transform scale" but instead sets width and height.