### PR TITLE
Fix image zooming out in some cases

### DIFF
--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -246,7 +246,7 @@ const mediumZoom = (selector, options = {}) => {
 
       const scaleX = Math.min(naturalWidth, viewportWidth) / width
       const scaleY = Math.min(naturalHeight, viewportHeight) / height
-      const scale = Math.min(scaleX, scaleY)
+      const scale = Math.max(1, Math.min(scaleX, scaleY));
       const translateX =
         (-left +
           (viewportWidth - width) / 2 +

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -244,9 +244,9 @@ const mediumZoom = (selector, options = {}) => {
         : zoomTarget.naturalHeight || viewportHeight
       const { top, left, width, height } = zoomTarget.getBoundingClientRect()
 
-      const scaleX = Math.min(naturalWidth, viewportWidth) / width
-      const scaleY = Math.min(naturalHeight, viewportHeight) / height
-      const scale = Math.max(1, Math.min(scaleX, scaleY));
+      const scaleX = Math.min(Math.max(width, naturalWidth), viewportWidth) / width;
+      const scaleY = Math.min(Math.max(height, naturalHeight), viewportHeight) / height;
+      const scale = Math.max(Math.min(scaleX, scaleY);
       const translateX =
         (-left +
           (viewportWidth - width) / 2 +


### PR DESCRIPTION
In some cases, pressing an image makes it zoom out. This pull requests sets the minimal scale of the zoom to 1.

Gif of the issue:
![image](https://user-images.githubusercontent.com/31186542/125167307-8827d800-e1a8-11eb-9fa7-ac890ac7a118.gif)

