### PR TITLE
Support for prefers-reduced-motion #178

### DIFF
--- a/src/medium-zoom.css
+++ b/src/medium-zoom.css
@@ -30,6 +30,12 @@
   transition: transform 300ms cubic-bezier(0.2, 0, 0.2, 1) !important;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .medium-zoom-image {
+    transition: transform 1ms !important;
+  }
+}
+
 .medium-zoom-image--hidden {
   visibility: hidden;
 }


### PR DESCRIPTION
## Summary

This resolves #178

## Result

A basic fix to cut `transition-duration` down to `1ms`. We can consider a fade in the future.

This is an opinionated fix that cannot be configured, but it should be okay for an accessibility requirement.
