### PR TITLE
fix: remove `loading` attribute on HD target

### DIFF
--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -346,6 +346,8 @@ const mediumZoom = (selector, options = {}) => {
         // Reset the `scrset` property or the HD image won't load.
         active.zoomedHd.removeAttribute('srcset')
         active.zoomedHd.removeAttribute('sizes')
+        // Remove loading attribute so the browser can load the image normally
+        active.zoomedHd.removeAttribute('loading')
 
         active.zoomedHd.src = active.zoomed.getAttribute('data-zoom-src')
 


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request 🙌
  This template helps you create an effective feature report.
-->

## Summary


Fixes #185

Remove any loading attribute the `zoomedHd` cloned node might have to allow the browser to load it normally

## Result

Same zoom behavior as expected. Before it used to glitch half the time and get stuck on a zoomed image and making the webpage unresponsive. The #185 ticket explains it.
