### PR TITLE
SVG images sometimes don't have a '.svg' extension

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ export const isNode = selector => selector && selector.nodeType === 1
 
 export const isSvg = image => {
   const source = image.currentSrc || image.src
-  return source.substr(-4).toLowerCase() === '.svg'
+  return source.toLowerCase().endsWith(".svg") || source.toLowerCase().includes("/svg/")
 }
 
 export const getImagesFromSelector = selector => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request 🙌
  This template helps you create an effective feature report.
-->

## Summary

SVG url test only verify '.svg'. See  #190 

## Result

test '/svg/' too
