### PR TITLE
feat: pure version of separating js and css

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev": "rollup --config --watch",
     "prebuild": "yarn run clean",
     "build": "rollup --config",
-    "postbuild": "cp ./src/medium-zoom.d.ts ./dist",
+    "postbuild": "cp ./src/medium-zoom.d.ts ./dist && cp ./src/medium-zoom.d.ts ./dist/pure/index.d.ts",
     "prepublishOnly": "npm run build",
     "lint": "eslint .",
     "format": "prettier --write *.{js,json,css,md} && yarn run lint --fix",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,4 +67,27 @@ export default [
     },
     plugins: [...sharedPlugins, terser(), license({ banner })],
   },
+  // pure
+  {
+    input: 'src/medium-zoom.js',
+    output: {
+      file: 'dist/pure/index.js',
+      format: 'es',
+    },
+    plugins: [...sharedPlugins, license({ banner })],
+  },
+  {
+    input: 'src/medium-zoom.css',
+    output: {
+      file: 'dist/pure/style.css',
+      format: 'es',
+    },
+    plugins: [
+      postcss({
+        extract: true,
+        minimize: true,
+      }),
+      license({ banner }),
+    ],
+  },
 ]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request 🙌
  This template helps you create an effective feature report.
-->

## Summary

As discussed in #203, provide a JS bundle without CSS injection and a separate CSS file.

fix #203.

<!-- Explain why you are making this change and link related issues (#ISSUE_NUMBER) -->

## Result

Add two outputs for rollup, generating the following files.

```diff
$ tree ./dist                                                          
 ./dist
 ├── medium-zoom.d.ts
 ├── medium-zoom.esm.js
 ├── medium-zoom.js
 ├── medium-zoom.min.js
+└── pure
+   ├── index.d.ts
+   ├── index.js
+   └── style.css

1 directory, 7 files
```

Usage:

```js
// import pure js files
import mediumZoom from "medium-zoom/dist/pure";

// import pure style files
import "medium-zoom/dist/pure/style.css";
```

**!!!**
**Tested in Astro only.**
**!!!**

<!-- Explain what you've changed and what's the result! -->
