### PR TITLE
perf: subscribe to the browser event only when attaching images

### DIFF
--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -121,9 +121,6 @@ const mediumZoom = (selector, options = {}) => {
 
     if (!hasImagesBefore && images.length !== 0) {
       document.addEventListener('click', _handleClick)
-      document.addEventListener('keyup', _handleKeyUp)
-      document.addEventListener('scroll', _handleScroll)
-      window.addEventListener('resize', close)
     }
 
     return zoom
@@ -158,9 +155,6 @@ const mediumZoom = (selector, options = {}) => {
 
     if (images.length === 0) {
       document.removeEventListener('click', _handleClick)
-      document.removeEventListener('keyup', _handleKeyUp)
-      document.removeEventListener('scroll', _handleScroll)
-      window.removeEventListener('resize', close)
     }
 
     return zoom
@@ -191,6 +185,8 @@ const mediumZoom = (selector, options = {}) => {
 
     return zoom
   }
+
+  let unregisterEvents;
 
   const open = ({ target } = {}) => {
     const _animate = () => {
@@ -307,6 +303,18 @@ const mediumZoom = (selector, options = {}) => {
       if (active.zoomed) {
         resolve(zoom)
         return
+      }
+
+      if (!unregisterEvents) {
+        document.addEventListener('keyup', _handleKeyUp)
+        document.addEventListener('scroll', _handleScroll)
+        window.addEventListener('resize', close)
+
+        unregisterEvents = () => {
+          document.removeEventListener('keyup', _handleKeyUp)
+          document.removeEventListener('scroll', _handleScroll)
+          window.removeEventListener('resize', close)
+        };
       }
 
       if (target) {
@@ -440,6 +448,11 @@ const mediumZoom = (selector, options = {}) => {
 
   const close = () =>
     new Promise(resolve => {
+      if (unregisterEvents) {
+        unregisterEvents();
+        unregisterEvents = undefined;
+      }
+
       if (isAnimating || !active.original) {
         resolve(zoom)
         return

--- a/src/medium-zoom.js
+++ b/src/medium-zoom.js
@@ -104,6 +104,8 @@ const mediumZoom = (selector, options = {}) => {
       []
     )
 
+    const hasImagesBefore = images.length !== 0;
+
     newImages
       .filter(newImage => images.indexOf(newImage) === -1)
       .forEach(newImage => {
@@ -116,6 +118,13 @@ const mediumZoom = (selector, options = {}) => {
         image.addEventListener(type, listener, options)
       })
     })
+
+    if (!hasImagesBefore && images.length !== 0) {
+      document.addEventListener('click', _handleClick)
+      document.addEventListener('keyup', _handleKeyUp)
+      document.addEventListener('scroll', _handleScroll)
+      window.addEventListener('resize', close)
+    }
 
     return zoom
   }
@@ -146,6 +155,13 @@ const mediumZoom = (selector, options = {}) => {
     })
 
     images = images.filter(image => imagesToDetach.indexOf(image) === -1)
+
+    if (images.length === 0) {
+      document.removeEventListener('click', _handleClick)
+      document.removeEventListener('keyup', _handleKeyUp)
+      document.removeEventListener('scroll', _handleScroll)
+      window.removeEventListener('resize', close)
+    }
 
     return zoom
   }
@@ -534,11 +550,6 @@ const mediumZoom = (selector, options = {}) => {
   }
 
   const overlay = createOverlay(zoomOptions.background)
-
-  document.addEventListener('click', _handleClick)
-  document.addEventListener('keyup', _handleKeyUp)
-  document.addEventListener('scroll', _handleScroll)
-  window.addEventListener('resize', close)
 
   const zoom = {
     open,


### PR DESCRIPTION
## Summary

Currently, we subscribe to the browser events `click`, `keyup`, `scroll`, and `resize` every time the `mediumZoom` function is called, which also happens during `clone`. Instead of always being subscribed to these events, it is much better to subscribe only when necessary. These events stack up on each other, significantly affecting performance and preventing the browser from garbage collecting. This is especially important in SPA applications when we use a component-based approach.

## Result

No performance degradation when images are missing or not active.