### PR TITLE
docs(readme): introduce Used by section

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ If that's the case, you can provide a `z-index` value in your CSS:
 
 ## Used by
 
-[![Dependents](https://api.usedby.dev/npm/medium-zoom?max=50)](https://www.npmjs.com/package/medium-zoom?activeTab=dependents)
+[![Dependents](https://api.usedby.dev/npm/medium-zoom?max=50&sort=stars)](https://github.com/francoischalifour/medium-zoom/network/dependents)
 
 <sub>Generated with <a href="https://usedby.dev/">usedby.dev</a></sub>
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ npx doctoc README.md --maxlevel 3
 - [Examples](#examples)
 - [Debugging](#debugging)
 - [Browser support](#browser-support)
+- [Used by](#used-by)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -519,6 +520,12 @@ If that's the case, you can provide a `z-index` value in your CSS:
     </a>
   </p>
 </blockquote>
+
+## Used by
+
+[![Dependents](https://api.usedby.dev/npm/medium-zoom?max=50)](https://www.npmjs.com/package/medium-zoom?activeTab=dependents)
+
+<sub>Generated with <a href="https://usedby.dev/">usedby.dev</a></sub>
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

This introduces a **Used by** section in the README to showcase the top users of `medium-zoom` and how many repositories rely on this package.

The image is generated with [usedby.dev](https://usedby.dev/) and refreshed every day.